### PR TITLE
Add missing orientation information.

### DIFF
--- a/Corpora/Orientations/Orientation-TR.Wiki.tsv
+++ b/Corpora/Orientations/Orientation-TR.Wiki.tsv
@@ -36,7 +36,7 @@ TR	Refah	RRF	https://en.wikipedia.org/wiki/Welfare_Party	-
 TR	SHP	CL	https://en.wikipedia.org/wiki/Social_Democratic_Populist_Party_(Turkey)	-
 TR	SODEP	CL	https://en.wikipedia.org/wiki/Social_Democracy_Party_(Turkey)	-
 TR	SOL	LLF	https://en.wikipedia.org/wiki/Left_Party_(Turkey)	-
-TR	YENİPARTİ	-	https://en.wikipedia.org/wiki/New_Party_(Turkey)	No information about political orientation on Wikipedia.
+TR	YENİPARTİ	CL	https://en.wikipedia.org/wiki/New_Party_(Turkey)	Information is based on Turkish Wikipedia page, no information about political orientation on English Wikipedia.
 TR	YTP	CR	https://en.wikipedia.org/wiki/New_Turkey_Party_(1961)	-
 TR	YURTP	R	https://en.wikipedia.org/wiki/Homeland_Party_(Turkey)	-
 TR	Zafer	RRF	https://en.wikipedia.org/wiki/Victory_Party_(Turkey)	-


### PR DESCRIPTION
This is only adding orientation for a single party (Yeni Parti), as specified by the [Turkish  Wikipedia page](https://tr.wikipedia.org/wiki/Yeni_Parti_(2008)), although the English Wikipedia page does not specify the orientation.

This is a rather short-lived splinter party, having only a single member in the corpus. So, if we are strict about the English Wikipedia reference, skipping it would not hurt either. I will consult with a political scientist and if I get confirmation, I will also update the English Wiki page.